### PR TITLE
Stats update route 2

### DIFF
--- a/app/routes/stats.py
+++ b/app/routes/stats.py
@@ -9,6 +9,7 @@ router = APIRouter()
 
 from fastapi import Depends
 
+
 @router.post("/create_user_stats")
 def create_user_stats(user: dict, current_user: dict = Depends(get_current_user)):
     """
@@ -63,6 +64,8 @@ def get_user_stats(user_id: str):
     except Exception as e:
         print("Error fetching user stats:", e)
         raise HTTPException(status_code=500, detail=str(e))
+
+
 from datetime import datetime, timedelta
 
 
@@ -80,7 +83,7 @@ def update_user_stats(user: dict, current_user: dict = Depends(get_current_user)
     user_id = current_user.get("user_id")
 
     if not user_id:
-        #should not happen for an authenticated request, but guard anyway.
+        # should not happen for an authenticated request, but guard anyway.
         raise HTTPException(status_code=400, detail="Missing authenticated user_id")
 
     try:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -12,7 +12,11 @@ def _make_auth_user_for_mock(mock_id: str, display_name: str = "Test User"):
     return the shape of current_user returned by app.auth.get_current_user
     (adjust fields as needed by your auth implementation)
     """
-    return {"user_id": mock_id, "username": display_name, "email": f"{mock_id[:8]}@example.com"}
+    return {
+        "user_id": mock_id,
+        "username": display_name,
+        "email": f"{mock_id[:8]}@example.com",
+    }
 
 
 def test_create_user_stats_creates_entry_and_gets_saved():


### PR DESCRIPTION
Second attempt at update stats route. Includes feedback from @dani017 regarding authentication handling. The POST route to create a new user in the stats table now requires authentication as does the PUT route to update user stats. I also separated out the tests more from the initial PR. See @dani017 's comments here: https://github.com/CrossWars-Project/Backend/pull/42

I chose to checkout a new branch because the previous one was very old and behind main, and I had also made some bad changes and just wanted a clean start.