### PR TITLE
Fix CORS allowed origins to include preview and production

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,9 +12,9 @@ app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        "http://localhost:5173",
+        "http://localhost:5173",  # default npm run dev route
         "http://127.0.0.1:5173",
-        "http://localhost:4173",  # npm run preview
+        "http://localhost:4173",  # common npm run preview route
         "https://crosswars.xyz",  # No trailing slash
         "https://www.crosswars.xyz",  # Support both www and non-www
     ],


### PR DESCRIPTION
Backend CORS fixed to allow http://localhost:4173 (npm run preview) (vite sets 4173 as the preview port sometimes) and https://crosswars.xyz (live site) still allows http://localhost:5173 (npm run dev)